### PR TITLE
fix(downloads): use cached release data instead of fetching from GitHub

### DIFF
--- a/docs/components/LatestRelease.vue
+++ b/docs/components/LatestRelease.vue
@@ -4,11 +4,11 @@ import Markdown from "./Markdown.vue";
 
 export default {
   async setup() {
-    const latestReleaseResponse = await fetch("https://api.github.com/repos/qw-group/ezquake-source/releases/latest");
-    const latestRelease = await latestReleaseResponse.json()
+    const releasesResponse = await fetch("https://raw.githubusercontent.com/vikpe/qw-data/refs/heads/main/github/ezquake_releases.json");
+    const releases = await releasesResponse.json()
 
     return {
-      latestRelease
+      latestRelease: releases[0]
     }
   },
   components: {

--- a/docs/components/PreviousReleases.vue
+++ b/docs/components/PreviousReleases.vue
@@ -2,7 +2,7 @@
 
 export default {
   async setup() {
-    const releasesResponse = await fetch("https://api.github.com/repos/qw-group/ezquake-source/releases");
+    const releasesResponse = await fetch("https://raw.githubusercontent.com/vikpe/qw-data/refs/heads/main/github/ezquake_releases.json");
     const releases = await releasesResponse.json()
     const prevReleaseLimit = 5;
 


### PR DESCRIPTION
to circumvent GitHub API rate limiting..